### PR TITLE
Bugfix/oc 232 minimize user information

### DIFF
--- a/extensions/users-permissions/config/routes.json
+++ b/extensions/users-permissions/config/routes.json
@@ -1,43 +1,43 @@
 {
   "routes": [{
-    "method": "PUT",
-    "path": "/users/me",
-    "handler": "User.updateMe",
-    "config": {
-      "policies": [],
-      "prefix": ""
-    }
-  },
-  {
-    "method": "GET",
-    "path": "/users",
-    "handler": "User.retrieveUsers",
-    "config": {
+      "method": "PUT",
+      "path": "/users/me",
+      "handler": "User.updateMe",
+      "config": {
+        "policies": [],
+        "prefix": ""
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/users",
+      "handler": "User.retrieveUserIds",
+      "config": {
         "policies": [],
         "prefix": "",
         "description": "Retrieve all user documents",
         "tag": {
-            "plugin": "users-permissions",
-            "name": "User",
-            "actionType": "find"
+          "plugin": "users-permissions",
+          "name": "User",
+          "actionType": "find"
         }
-    }
-},
-  {
-    "method": "GET",
-    "path": "/users/:id",
-    "handler": "User.retrieveUser",
-    "config": {
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/users/:id",
+      "handler": "User.retrieveUser",
+      "config": {
         "policies": [],
         "prefix": "",
         "description": "Retrieve single user document",
         "tag": {
-            "plugin": "users-permissions",
-            "name": "User",
-            "actionType": "find"
+          "plugin": "users-permissions",
+          "name": "User",
+          "actionType": "find"
         }
+      }
     }
-}
 
-]
+  ]
 }

--- a/extensions/users-permissions/controllers/User.js
+++ b/extensions/users-permissions/controllers/User.js
@@ -17,18 +17,8 @@ const { sanitizeEntity } = require('strapi-utils')
 const {
   getFrontendFieldsUser,
   getUserId,
+  userFieldsToIgnoreOnUpdate,
 } = require('../services/sanitize-user')
-
-const userFieldsToIgnoreOnUpdate = [
-  'blocked',
-  'confirmed',
-  'created_at',
-  'role',
-  'provider',
-  'articles',
-  'specific_vacancy_site',
-  'is_ordina_employee',
-]
 
 const sanitizeUser = (user) =>
   sanitizeEntity(user, {

--- a/extensions/users-permissions/controllers/User.js
+++ b/extensions/users-permissions/controllers/User.js
@@ -14,7 +14,10 @@
 
 const _ = require('lodash')
 const { sanitizeEntity } = require('strapi-utils')
-const { getUserWithoutPii } = require('../services/sanitize-user');
+const {
+  getFrontendFieldsUser,
+  getUserId,
+} = require('../services/sanitize-user')
 
 const sanitizeUser = (user) =>
   sanitizeEntity(user, {
@@ -26,22 +29,21 @@ const formatError = (error) => [
 ]
 
 module.exports = {
-
-  async retrieveUsers() {
-    const queryResult = await strapi.query('user', 'users-permissions').find();
-    const users = queryResult.map(user => sanitizeUser(getUserWithoutPii(user)));
-    return users;
+  async retrieveUserIds() {
+    const queryResult = await strapi.query('user', 'users-permissions').find()
+    const users = queryResult.map((user) => sanitizeUser(getUserId(user)))
+    return users
   },
 
   async retrieveUser(ctx) {
-    const { id } = ctx.params;
+    const { id } = ctx.params
 
     if (id == 'me') {
       return sanitizeUser(ctx.state.user)
     }
 
-    const user = await strapi.query('user', 'users-permissions').findOne({ id });
-    return sanitizeUser(getUserWithoutPii(user));
+    const user = await strapi.query('user', 'users-permissions').findOne({ id })
+    return sanitizeUser(getFrontendFieldsUser(user))
   },
 
   /**

--- a/extensions/users-permissions/controllers/User.js
+++ b/extensions/users-permissions/controllers/User.js
@@ -19,6 +19,17 @@ const {
   getUserId,
 } = require('../services/sanitize-user')
 
+const userFieldsToIgnoreOnUpdate = [
+  'blocked',
+  'confirmed',
+  'created_at',
+  'role',
+  'provider',
+  'articles',
+  'specific_vacancy_site',
+  'is_ordina_employee',
+]
+
 const sanitizeUser = (user) =>
   sanitizeEntity(user, {
     model: strapi.query('user', 'users-permissions').model,
@@ -117,9 +128,14 @@ module.exports = {
       }
     }
 
-    let updateData = {
-      ...ctx.request.body,
-    }
+    let updateData = Object.entries(ctx.request.body).reduce((body, entry) => {
+      const [key, value] = entry
+      if (userFieldsToIgnoreOnUpdate.includes(key)) {
+        return body
+      }
+      body[key] = value
+      return body
+    }, {})
 
     if (_.has(ctx.request.body, 'password') && password === user.password) {
       delete updateData.password

--- a/extensions/users-permissions/controllers/User.js
+++ b/extensions/users-permissions/controllers/User.js
@@ -1,10 +1,4 @@
 'use strict'
-/**
- * This code was mainly copied from https://github.com/strapi/strapi/blob/v3.0.0/packages/strapi-plugin-users-permissions/controllers/User.js
- * This is done in https://www.youtube.com/watch?v=ITk-pYtOCnQ
- * Note that it is an old version of Strapi (3.0.0)
- * 03-02-22 JM
- */
 
 /**
  * User.js controller
@@ -46,6 +40,13 @@ module.exports = {
     const user = await strapi.query('user', 'users-permissions').findOne({ id })
     return sanitizeUser(getFrontendFieldsUser(user))
   },
+
+  /**
+   * This code was mainly copied from https://github.com/strapi/strapi/blob/v3.0.0/packages/strapi-plugin-users-permissions/controllers/User.js
+   * This is done in https://www.youtube.com/watch?v=ITk-pYtOCnQ
+   * Note that it is an old version of Strapi (3.0.0)
+   * 03-02-22 JM
+   */
 
   /**
    * Retrieve user records.

--- a/extensions/users-permissions/services/sanitize-user.js
+++ b/extensions/users-permissions/services/sanitize-user.js
@@ -1,20 +1,31 @@
 const userFrontendFields = [
-  'username',
-  'name',
-  'biography',
-  'profile_picture',
-  'tagline',
-  'github',
-  'linked_in',
-  'facebook',
-  'twitter',
-  'email',
-  'website',
-  'specific_vacancy_site',
-  'is_ordina_employee',
   'articles',
-  'id',
+  'biography',
   'display_email_on_profile',
+  'email',
+  'facebook',
+  'github',
+  'id',
+  'is_ordina_employee',
+  'linked_in',
+  'name',
+  'profile_picture',
+  'specific_vacancy_site',
+  'tagline',
+  'twitter',
+  'username',
+  'website',
+]
+
+const userFieldsToIgnoreOnUpdate = [
+  'articles',
+  'blocked',
+  'confirmed',
+  'created_at',
+  'is_ordina_employee',
+  'provider',
+  'role',
+  'specific_vacancy_site',
 ]
 
 const getUserId = (user) => {
@@ -40,4 +51,5 @@ const getFrontendFieldsUser = (user) => {
 module.exports = {
   getFrontendFieldsUser,
   getUserId,
+  userFieldsToIgnoreOnUpdate,
 }

--- a/extensions/users-permissions/services/sanitize-user.js
+++ b/extensions/users-permissions/services/sanitize-user.js
@@ -1,14 +1,43 @@
-const getUserWithoutPii = (user) => {
-    if (!user) return null
+const userFrontendFields = [
+  'username',
+  'name',
+  'biography',
+  'profile_picture',
+  'tagline',
+  'github',
+  'linked_in',
+  'facebook',
+  'twitter',
+  'email',
+  'website',
+  'specific_vacancy_site',
+  'is_ordina_employee',
+  'articles',
+  'id',
+  'display_email_on_profile',
+]
 
-    if (!user.display_email_on_profile) {
-        delete user.email;
-        return user;
-    }
+const getUserId = (user) => {
+  if (!user) return null
 
-    return user
+  return { id: user.id }
+}
+
+const getFrontendFieldsUser = (user) => {
+  if (!user) return null
+
+  const newUser = userFrontendFields.reduce((_newUser, key) => {
+    _newUser[key] = user[key]
+    return _newUser
+  }, {})
+
+  if (!user.display_email_on_profile) {
+    delete newUser.email
+    return newUser
+  }
 }
 
 module.exports = {
-    getUserWithoutPii,
+  getFrontendFieldsUser,
+  getUserId,
 }


### PR DESCRIPTION
This PR fixes OC-232. It does three things:

- We only return the ids of users with a GET on `/users`
- We only return certain fields of a user with a GET on `/users/:id`
- We remove some fields from the body on a PUT on `/users/me`