### PR TITLE
Remove number of logins

### DIFF
--- a/extensions/users-permissions/models/User.settings.json
+++ b/extensions/users-permissions/models/User.settings.json
@@ -130,9 +130,6 @@
     "events": {
       "via": "speakers",
       "collection": "event"
-    },
-    "number_of_logins": {
-      "type": "integer"
     }
   }
 }


### PR DESCRIPTION
Something went wrong in [this PR](https://github.com/OrdinaNederland/to-the-root-backend/pull/9) with removing the number_of_logins field. This PR just removes the number_of_logins field from the User. The frontend changes are done in [this PR](https://github.com/OrdinaNederland/to-the-root-frontend/pull/63)