### PR TITLE
Return query functionality to articles, events, featureds

### DIFF
--- a/api/article/controllers/article.js
+++ b/api/article/controllers/article.js
@@ -1,45 +1,60 @@
-const { sanitizeEntity } = require('strapi-utils');
-const { transformUserForArticlePage, transformUserForComments } = require('../../../extensions/users-permissions/services/sanitize-user');
+const { sanitizeEntity } = require('strapi-utils')
+const {
+  transformUserForArticlePage,
+  transformUserForComments,
+} = require('../../../extensions/users-permissions/services/sanitize-user')
 
 module.exports = {
-    async find() {
-        const entities = await strapi.services.article.find();
+  async find(ctx) {
+    let articles
 
-        return entities.map(entity => {
-            if (entity.author) {
-                entity.author = transformUserForArticlePage(entity.author)
-            }
-            return sanitizeEntity(entity, { model: strapi.models.article });
-        })
-    },
+    if (ctx.query._q) {
+      articles = await strapi.services.article.search(ctx.query)
+    } else {
+      articles = await strapi.services.article.find(ctx.query)
+    }
 
-    async findOne(ctx) {
-        const article = await strapi.services.article.findOne({ slug: ctx.params.slug });
+    return articles.map((article) => {
+      if (article.author) {
+        article.author = transformUserForArticlePage(article.author)
+      }
+      return sanitizeEntity(article, { model: strapi.models.article })
+    })
+  },
 
-        article.comments = await Promise.all(article.comments.map(async (comment) => {
-            const user = await strapi.query('user', 'users-permissions').findOne({ id: comment.user })
-            comment.user = transformUserForComments(user)
-            return comment
-        }))
+  async findOne(ctx) {
+    const article = await strapi.services.article.findOne({
+      slug: ctx.params.slug,
+    })
 
-        if (article.author) {
-            article.author = transformUserForArticlePage(article.author)
-        }
+    article.comments = await Promise.all(
+      article.comments.map(async (comment) => {
+        const user = await strapi
+          .query('user', 'users-permissions')
+          .findOne({ id: comment.user })
+        comment.user = transformUserForComments(user)
+        return comment
+      }),
+    )
 
-        return sanitizeEntity(article, { model: strapi.models.article });
-    },
+    if (article.author) {
+      article.author = transformUserForArticlePage(article.author)
+    }
 
-    async comment(ctx) {
-        ctx.request.body.article = ctx.params.id;
-        const entity = await strapi.services.comment.create(ctx.request.body);
+    return sanitizeEntity(article, { model: strapi.models.article })
+  },
 
-        return sanitizeEntity(entity, { model: strapi.models.comment });
-    },
+  async comment(ctx) {
+    ctx.request.body.article = ctx.params.id
+    const entity = await strapi.services.comment.create(ctx.request.body)
 
-    async like(ctx) {
-        ctx.request.body.article = ctx.params.id;
-        const entity = await strapi.services.like.create(ctx.request.body);
+    return sanitizeEntity(entity, { model: strapi.models.comment })
+  },
 
-        return sanitizeEntity(entity, { model: strapi.models.like });
-    },
+  async like(ctx) {
+    ctx.request.body.article = ctx.params.id
+    const entity = await strapi.services.like.create(ctx.request.body)
+
+    return sanitizeEntity(entity, { model: strapi.models.like })
+  },
 }

--- a/api/event/controllers/event.js
+++ b/api/event/controllers/event.js
@@ -1,25 +1,37 @@
-const { sanitizeEntity } = require('strapi-utils');
-const { transformUserForEventPage } = require('../../../extensions/users-permissions/services/sanitize-user');
+const { sanitizeEntity } = require('strapi-utils')
+const {
+  transformUserForEventPage,
+} = require('../../../extensions/users-permissions/services/sanitize-user')
 
 module.exports = {
-    async find() {
-        const entities = await strapi.services.event.find();
+  async find(ctx) {
+    let events
 
-        return entities.map(entity => {
-            if (entity.speakers) {
-                entity.speakers = entity.speakers.map(speaker => transformUserForEventPage(speaker))
-            }
-            return sanitizeEntity(entity, { model: strapi.models.event });
-        })
-    },
+    if (ctx.query._q) {
+      events = await strapi.services.event.search(ctx.query)
+    } else {
+      events = await strapi.services.event.find(ctx.query)
+    }
 
-    async findOne(ctx) {
-        const entity = await strapi.services.event.findOne({ id: ctx.params.id });
+    return events.map((event) => {
+      if (event.speakers) {
+        event.speakers = event.speakers.map((speaker) =>
+          transformUserForEventPage(speaker),
+        )
+      }
+      return sanitizeEntity(event, { model: strapi.models.event })
+    })
+  },
 
-        if (entity.speakers) {
-            entity.speakers = entity.speakers.map(speaker => transformUserForEventPage(speaker))
-        }
+  async findOne(ctx) {
+    const entity = await strapi.services.event.findOne({ id: ctx.params.id })
 
-        return sanitizeEntity(entity, { model: strapi.models.event });
-    },
-};
+    if (entity.speakers) {
+      entity.speakers = entity.speakers.map((speaker) =>
+        transformUserForEventPage(speaker),
+      )
+    }
+
+    return sanitizeEntity(entity, { model: strapi.models.event })
+  },
+}

--- a/api/featured/controllers/featured.js
+++ b/api/featured/controllers/featured.js
@@ -1,7 +1,9 @@
-'use strict';
+'use strict'
 
-const { sanitizeEntity } = require("strapi-utils/lib");
-const { transformUserForArticlePage } = require("../../../extensions/users-permissions/services/sanitize-user");
+const { sanitizeEntity } = require('strapi-utils/lib')
+const {
+  transformUserForArticlePage,
+} = require('../../../extensions/users-permissions/services/sanitize-user')
 
 /**
  * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
@@ -9,14 +11,22 @@ const { transformUserForArticlePage } = require("../../../extensions/users-permi
  */
 
 module.exports = {
-    async find() {
-        const featureds = await strapi.services.featured.find();
+  async find(ctx) {
+    let featureds
 
-        return featureds.map(featured => {
-            if (featured.article.author) {
-                featured.article.author = transformUserForArticlePage(featured.article.author)
-            }
-            return sanitizeEntity(featured, { model: strapi.models.article });
-        })
-    },
-};
+    if (ctx.query._q) {
+      featureds = await strapi.services.featured.search(ctx.query)
+    } else {
+      featureds = await strapi.services.featured.find(ctx.query)
+    }
+
+    return featureds.map((featured) => {
+      if (featured.article.author) {
+        featured.article.author = transformUserForArticlePage(
+          featured.article.author,
+        )
+      }
+      return sanitizeEntity(featured, { model: strapi.models.article })
+    })
+  },
+}


### PR DESCRIPTION
This PR adds (or returns) the functionality for using query parameters for Strapi.
This was broken when adding our own controllers

The fact that related articles where the same for all articles waas a symtom of this: we used query parameters to get those for each article.

Events and Featureds are fixed as well to prevent the same error in the future for those entities. 

We should really pick up unit testing for Strapi to prevent this from happening in the future. I made [a Jira issue](https://one-community.atlassian.net/browse/OC-283) for this